### PR TITLE
fix octal bug

### DIFF
--- a/ahs.bat
+++ b/ahs.bat
@@ -3,12 +3,8 @@ rem src: https://github.com/srd7/ActiveHoursSlider
 
 @echo off
 
-rem Get current time.
-rem replace ' ' to '0'.
-set now=%time: =0%
-
-rem Extract hour
-set hour=%now:~0,2%
+rem Get current time and extract hour.
+set hour=%time:~0,2%
 
 rem Start hour is 2 hours ago.
 rem End hour is 10 hours later.


### PR DESCRIPTION
`08` や `09` が不正な8進数として認識されていた問題を修正。

動作確認したところ、そもそも半角スペースをゼロでreplaceする必要はなかったため、`replace` する処理を取り除いた。
すなわち
` 8` と `22` を足し算しても `30` になってくれるようだ。
